### PR TITLE
Add meta viewport header to disable font inflation in options on Android.

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -5,6 +5,7 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width"/>
         <link rel="stylesheet" href="options.css"/>
     </head>
     <body>


### PR DESCRIPTION
If you've got _Settings -> Accessibility -> Use system font size_ enabled, without this Firefox on Android thinks your options page is a desktop page and tries to apply font inflation to it, which slightly breaks the page layout.